### PR TITLE
fix: update release workflow to match working markform config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
@@ -32,11 +32,10 @@ jobs:
         run: pnpm build && pnpm publint
 
       # Publish with OIDC trusted publishing (no NPM_TOKEN needed)
-      # Note: actions/setup-node with registry-url automatically configures
-      # authentication via OIDC. The provenance flag enables build attestation.
       - name: Publish to npm
-        working-directory: packages/tryscript
-        run: npm publish --access public --provenance
+        run: pnpm -r publish --access public --no-git-checks
+        env:
+          NPM_CONFIG_PROVENANCE: true
 
       # Extract version from tag and get changelog section
       - name: Extract release notes


### PR DESCRIPTION
Update workflow to match the working markform release configuration:
- Use actions/checkout@v5 and actions/setup-node@v6
- Use node-version: 24
- Use pnpm -r publish with NPM_CONFIG_PROVENANCE