### PR TITLE
chore: release tryscript v0.1.1

### DIFF
--- a/.changeset/patch-26c9435db0d9e51a.md
+++ b/.changeset/patch-26c9435db0d9e51a.md
@@ -1,5 +1,0 @@
----
-"tryscript": patch
----
-
-Add built-in coverage support for CLI testing and fix c8 path issues

--- a/packages/tryscript/CHANGELOG.md
+++ b/packages/tryscript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # tryscript
 
+## 0.1.1
+
+### Patch Changes
+
+- 634984e: Add built-in coverage support for CLI testing and fix c8 path issues
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/tryscript/package.json
+++ b/packages/tryscript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tryscript",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Golden testing for CLI applications - TypeScript port of trycmd",
   "license": "MIT",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Summary

Release v0.1.1 with the following changes since v0.1.0:

- **feat**: Add built-in code coverage support for CLI testing
- **fix**: Resolve c8 path and shell glob expansion issues in coverage
- **docs**: README improvements with CI/coverage/npm badges, coverage documentation
- **ci**: Combine unit test and golden test coverage workflow

## Test plan
- [x] Tests pass locally
- [x] Build succeeds