### PR TITLE
fix: make README golden test more resilient to content changes

### DIFF
--- a/packages/tryscript/tests/cli.tryscript.md
+++ b/packages/tryscript/tests/cli.tryscript.md
@@ -90,14 +90,12 @@ $ node $TRYSCRIPT_TEST_DIR/../dist/bin.mjs --version
 # Test: readme command displays README
 
 ```console
-$ node $TRYSCRIPT_TEST_DIR/../dist/bin.mjs readme --raw | head -10
+$ node $TRYSCRIPT_TEST_DIR/../dist/bin.mjs readme --raw | head -20
 # tryscript
 
-[![CI][..]
 ...
 Golden testing for CLI applications - a TypeScript port of [trycmd](https://github.com/assert-rs/trycmd).
-
-## What It Does
+...
 ? 0
 ```
 


### PR DESCRIPTION
## Summary
- Updated the `readme command displays README` golden test to be more resilient to README content changes
- Previously the test expected specific badge line format (`[![CI][..]`), which broke when additional badges were added
- Now uses `...` elision patterns to skip over variable content (badges, notes) and just verifies the title and key description are present
- Increased `head -10` to `head -20` to ensure enough content is captured

## Test plan
- [x] All unit tests pass (`pnpm test`)
- [x] All golden tests pass (`pnpm test:golden`)
- [x] Full precommit check passes (`pnpm precommit`)