### PR TITLE
docs: document sourcemap requirement for accurate coverage reporting

### DIFF
--- a/docs/tryscript-reference.md
+++ b/docs/tryscript-reference.md
@@ -372,6 +372,57 @@ by spawned CLI processes. Install c8 as a dev dependency:
 npm install -D c8
 ```
 
+### Sourcemap Requirement
+
+**Important**: Coverage reports map back to source files only if your build generates sourcemaps.
+Without sourcemaps, reports show bundled filenames instead of source paths:
+
+| Build Configuration | Coverage Report Shows |
+|---------------------|----------------------|
+| Sourcemaps disabled | `cli-BXvEEW6O.mjs` (34% coverage) |
+| Sourcemaps enabled | `src/cli/commands/status.ts` (83% coverage) |
+
+Enable sourcemaps in your build tool:
+
+**tsdown / tsup:**
+```typescript
+// tsdown.config.ts or tsup.config.ts
+export default defineConfig({
+  sourcemap: true,
+  // ... other options
+});
+```
+
+**esbuild:**
+```typescript
+await esbuild.build({
+  sourcemap: true,
+  // ... other options
+});
+```
+
+**rollup:**
+```javascript
+// rollup.config.js
+export default {
+  output: {
+    sourcemap: true,
+  },
+};
+```
+
+**Vite:**
+```typescript
+// vite.config.ts
+export default defineConfig({
+  build: {
+    sourcemap: true,
+  },
+});
+```
+
+After enabling sourcemaps, rebuild your project before running coverage.
+
 Configure coverage in `tryscript.config.ts`:
 
 ```typescript


### PR DESCRIPTION
## Summary

Addresses #18 by adding user-facing documentation explaining the sourcemap requirement for accurate c8 coverage reporting.

### Changes

Added a new "Sourcemap Requirement" section to `docs/tryscript-reference.md` (the user documentation) that:

- Explains that coverage reports map back to source files only when builds generate sourcemaps
- Shows the before/after difference (bundled filenames vs readable source paths)
- Provides configuration examples for common build tools:
  - tsdown / tsup
  - esbuild
  - rollup
  - Vite

### Why This Matters

Without sourcemaps enabled in the build configuration, coverage reports show obfuscated bundled filenames like `cli-BXvEEW6O.mjs` instead of readable source paths like `src/cli/commands/status.ts`. This makes it difficult for users to understand which source files need more test coverage.

## Manual Validation

1. Review the new documentation section in `docs/tryscript-reference.md` (lines 375-424)
2. Verify the configuration examples are correct for each build tool
3. Confirm the explanation is clear for users unfamiliar with sourcemaps

Fixes #18