### PR TITLE
chore: release tryscript v0.1.7

### DIFF
--- a/.changeset/patch-34eb6248043ad6a9.md
+++ b/.changeset/patch-34eb6248043ad6a9.md
@@ -1,0 +1,5 @@
+---
+"tryscript": patch
+---
+
+Wildcard expansion, unknown wildcards, capture log, extended fence parsing, and update block alignment fixes

--- a/.changeset/patch-34eb6248043ad6a9.md
+++ b/.changeset/patch-34eb6248043ad6a9.md
@@ -1,5 +1,0 @@
----
-"tryscript": patch
----
-
-Wildcard expansion, unknown wildcards, capture log, extended fence parsing, and update block alignment fixes

--- a/packages/tryscript/CHANGELOG.md
+++ b/packages/tryscript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # tryscript
 
+## 0.1.7
+
+### Patch Changes
+
+- 9f93f08: Wildcard expansion, unknown wildcards, capture log, extended fence parsing, and update block alignment fixes
+
 ## 0.1.6
 
 ### Patch Changes

--- a/packages/tryscript/package.json
+++ b/packages/tryscript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tryscript",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Golden testing for CLI applications - TypeScript port of trycmd",
   "license": "MIT",
   "author": "Joshua Levy",


### PR DESCRIPTION
## Release v0.1.7

### Changes

**Wildcard Expansion & Capture Log (#41)**
- New unknown wildcard syntax (`???`/`[??]`) for temporary placeholders during test authoring
- Surgical wildcard expansion via `--expand`, `--expand-generic`, `--expand-all` CLI flags
- `--capture-log <path>` writes a YAML sidecar with matched wildcard values
- Documentation restructured around wildcard categories (named > unknown > generic)

**Extended Fence Parsing & Update Fixes (#42)**
- Parser supports 4+ backtick fences (CommonMark extended fences), enabling nested triple-backtick code blocks in expected output
- Fix `--update` rewriting wrong block when `--filter`/`<!-- only -->` runs a subset of tests
- Updater and expander preserve original fence length when rewriting blocks

**Documentation**
- README revised for clarity, readability, and accuracy

### Release Notes (for GitHub Release)

```markdown
## What's Changed

### Features
- Unknown wildcard syntax (`???`/`[??]`) for temporary placeholders during test authoring
- Surgical wildcard expansion via `--expand`, `--expand-generic`, `--expand-all` CLI flags
- `--capture-log <path>` writes a YAML sidecar with matched wildcard values
- Support for 4+ backtick fences (CommonMark extended fences) for nested code blocks

### Fixes
- Fix `--update` rewriting wrong block when `--filter`/`<!-- only -->` runs a subset of tests
- Updater and expander preserve original fence length when rewriting blocks

### Documentation
- README revised for clarity and restructured wildcard documentation

**Full Changelog**: https://github.com/jlevy/tryscript/compare/v0.1.6...v0.1.7
```

### Test Results
- 118 unit tests passing
- All golden self-tests passing
- `pnpm precommit` clean

Made with [Cursor](https://cursor.com)